### PR TITLE
修正 bc 系统邮件发送失败问题

### DIFF
--- a/bc-message/docs/update/20171219_更新发件邮箱配置.sql
+++ b/bc-message/docs/update/20171219_更新发件邮箱配置.sql
@@ -1,0 +1,6 @@
+﻿update bc_option_item set value_ = '13318786102@139.com'
+  where pid = (select id from bc_option_group where key_ = 'bc.mailSender') and key_ = 'username';
+update bc_option_item set value_ = 'gf81800088'
+  where pid = (select id from bc_option_group where key_ = 'bc.mailSender') and key_ = 'password';
+update bc_option_item set value_ = 'smtp.139.com'
+  where pid = (select id from bc_option_group where key_ = 'bc.mailSender') and key_ = 'host';

--- a/bc-message/pom.xml
+++ b/bc-message/pom.xml
@@ -9,7 +9,7 @@
 	<description>消息管理</description>
 	<dependencies>
 		<dependency>
-		    <groupId>javax.mail</groupId>
+			<groupId>javax.mail</groupId>
 		    <artifactId>mail</artifactId>
 		</dependency>
 		<dependency>
@@ -23,6 +23,27 @@
 		<dependency>
 			<groupId>cn.bc</groupId>
 			<artifactId>bc-log</artifactId>
+		</dependency>
+		<!-- Unit test-->
+		<dependency>
+			<groupId>org.aspectj</groupId>
+			<artifactId>aspectjweaver</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.hibernate</groupId>
+			<artifactId>hibernate-entitymanager</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.hibernate</groupId>
+			<artifactId>hibernate-java8</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.hibernate</groupId>
+			<artifactId>hibernate-validator</artifactId>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 </project>

--- a/bc-message/src/test/java/cn/bc/mail/MailServiceImplTest.java
+++ b/bc-message/src/test/java/cn/bc/mail/MailServiceImplTest.java
@@ -1,5 +1,12 @@
 package cn.bc.mail;
 
+import cn.bc.identity.domain.Actor;
+import cn.bc.identity.domain.ActorHistory;
+import cn.bc.identity.service.ActorHistoryService;
+import cn.bc.identity.service.ActorService;
+import cn.bc.identity.web.SystemContext;
+import cn.bc.identity.web.SystemContextHolder;
+import cn.bc.identity.web.SystemContextImpl;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,18 +19,33 @@ import org.springframework.transaction.annotation.Transactional;
 @ContextConfiguration("classpath:spring-test.xml")
 public class MailServiceImplTest {
 	MailService mailService;
+	@Autowired
+	public ActorService actorService;
+	@Autowired
+	public ActorHistoryService actorHistoryService;
 
 	@Autowired
 	public void setMailService(MailService mailService) {
 		this.mailService = mailService;
 	}
 
+	private void doSetUser() {
+		Actor a = actorService.loadByCode("may");
+		ActorHistory ah = actorHistoryService.loadByCode("may");
+		SystemContext context = new SystemContextImpl();
+		context.setAttr(SystemContext.KEY_USER, a);
+		context.setAttr(SystemContext.KEY_USER_HISTORY, ah);
+		SystemContextHolder.set(context);
+	}
+
 	@Test
 	public void testSend() {
+		doSetUser();
 		Mail mail = new Mail();
-		mail.setSubject("[BCMail:测试标题]");
-		mail.setContent("[BCMail:测试内容]\r\nreturn 换行测试！");
-		mail.setTo(new String[] { "rongjih@163.com", "rongjihuang@gmail.com" });
+		mail.setSubject("[BCMail:会议提醒]");
+		mail.setContent("[BCMail:提醒内容]\r\n请出准时出席周五的会议！");
+		mail.setHtml(true);
+		mail.setTo(new String[]{"1287635921@qq.com"});
 		this.mailService.send(mail);
 	}
 }

--- a/bc-message/src/test/resources/db.properties
+++ b/bc-message/src/test/resources/db.properties
@@ -1,0 +1,10 @@
+db_type=${db.type}
+jndi_name=${jndi.name}
+db_driverClassName=${db.driverClassName}
+db_password=${db.password}
+db_url=${db.url}
+db_username=${db.username}
+db_sequence=${db.sequence}
+hibernate_dialect=${hibernate.dialect}
+hibernate_showSql=${hibernate.show_sql}
+hibernate_hbm2ddl_auto=${hibernate.hbm2ddl.auto}

--- a/bc-message/src/test/resources/logback-test.xml
+++ b/bc-message/src/test/resources/logback-test.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+	<!-- http://logback.qos.ch/manual/layouts.html -->
+	<appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+		<encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+			<pattern>%d{HH:mm:ss.SSS} %-5level [%thread] %c{0}.%method:%line - %msg%n</pattern>
+		</encoder>
+	</appender>
+
+	<!-- 按照每天生成日志文件 http://blog.csdn.net/wangjunjun2008/article/details/18732019 -->
+	<appender name="rollingFile" class="ch.qos.logback.core.rolling.RollingFileAppender">
+		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+			<!--日志文件输出的文件名-->
+			<FileNamePattern>logback.%d{yyyy-MM-dd}.log</FileNamePattern>
+			<!--日志文件保留天数-->
+			<MaxHistory>30</MaxHistory>
+		</rollingPolicy>
+		<encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+			<!--格式化输出,%d:日期;%thread:线程名;%-5level：级别,从左显示5个字符宽度;%msg:日志消息;%n:换行符-->
+			<pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{50}.%method:%line - %msg%n</pattern>
+		</encoder>
+		<!--日志文件最大的大小-->
+		<triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+			<MaxFileSize>10MB</MaxFileSize>
+		</triggeringPolicy>
+	</appender>
+
+	<!-- hibernate -->
+	<logger name="org.hibernate" level="ERROR"/>
+
+	<logger name="cn.bc.mail" level="DEBUG"/>
+	<logger name="org.springframework.mail" level="DEBUG"/>
+	<logger name="org.springframework.mail.javamail" level="DEBUG"/>
+	<logger name="javax.mail" level="DEBUG"/>
+	<logger name="com.sun.mail" level="DEBUG"/>
+	<logger name="com.sun.mail.smtp" level="DEBUG"/>
+
+	<!-- 设置默认的日志级别: TRACE < DEBUG < INFO < WARN < ERROR -->
+	<root level="warn">
+		<appender-ref ref="console"/>
+		<appender-ref ref="rollingFile"/>
+	</root>
+</configuration>

--- a/bc-message/src/test/resources/spring-test-db.xml
+++ b/bc-message/src/test/resources/spring-test-db.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:tx="http://www.springframework.org/schema/tx"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context.xsd
+        http://www.springframework.org/schema/tx
+        http://www.springframework.org/schema/tx/spring-tx.xsd">
+	<!-- database setup-->
+	<context:property-placeholder location="classpath:db.properties"/>
+	<bean id="dataSource" class="org.springframework.jdbc.datasource.DriverManagerDataSource">
+		<property name="driverClassName" value="${db_driverClassName}"/>
+		<property name="url" value="${db_url}"/>
+		<property name="username" value="${db_username}"/>
+		<property name="password" value="${db_password}"/>
+	</bean>
+
+	<!-- jpa setup -->
+	<bean id="entityManagerFactory" class="org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean">
+		<!--<property name="persistenceUnitName" value="default" />-->
+		<property name="dataSource" ref="dataSource"/>
+		<property name="packagesToScan">
+			<list>
+				<value>cn.bc.message</value>
+				<value>cn.bc.identity</value>
+				<value>cn.bc.option</value>
+				<value>cn.bc.orm.jpa</value>
+				<value>cn.bc.log</value>
+				<value>cn.bc.docs</value>
+			</list>
+		</property>
+
+		<!-- 声明使用Hibernate的JPA适配器：注意如果不配置这个，应用异常时activiti的数据并不会回滚 -->
+		<property name="jpaVendorAdapter">
+			<bean class="org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter"/>
+		</property>
+
+		<!-- 声明使用Hibernate的JPA方言：如果配置了jpaVendorAdapter就无需配置这个，
+			因为 HibernateJpaVendorAdapter 默认已使用了 HibernateJpaDialect
+		<property name="jpaDialect">
+			<bean class="org.springframework.orm.jpa.vendor.HibernateJpaDialect"/>
+		</property> -->
+
+		<property name="jpaPropertyMap">
+			<map>
+				<entry key="hibernate.format_sql" value="true"/>
+				<entry key="hibernate.dialect" value="${hibernate_dialect}"/>
+				<!--<entry key="hibernate.hbm2ddl.auto" value="create"/>-->
+				<!--<entry key="hibernate.show_sql" value="${hibernate_showSql}"/>-->
+			</map>
+		</property>
+	</bean>
+	<bean id="transactionManager" class="org.springframework.orm.jpa.JpaTransactionManager">
+		<property name="entityManagerFactory" ref="entityManagerFactory"/>
+	</bean>
+	<tx:annotation-driven transaction-manager="transactionManager"/>
+
+	<bean id="jdbcTemplate" class="org.springframework.jdbc.core.JdbcTemplate">
+		<constructor-arg ref="dataSource"/>
+	</bean>
+</beans>

--- a/bc-message/src/test/resources/spring-test-mail.xml
+++ b/bc-message/src/test/resources/spring-test-mail.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
-	<!-- 邮件服务配置范例 -->
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd">
+	<!-- 邮件服务配置 -->
 	<bean id="mailSender" class="org.springframework.mail.javamail.JavaMailSenderImpl">
-		<property name="host" value="smtp.139.com" />
-		<property name="port" value="25" />
-		<property name="defaultEncoding" value="UTF-8" />
+		<property name="host" value="smtp.163.com"/>
+		<property name="port" value="25"/>
+		<property name="defaultEncoding" value="UTF-8"/>
 		<property name="javaMailProperties">
 			<props>
 				<!-- 是否需要auth认证 -->
@@ -16,24 +16,28 @@
 				<prop key="mail.smtp.timeout">25000</prop>
 
 				<prop key="mail.transport.protocol">smtp</prop>
-
+				<prop key="mail.debug">true</prop>
 				<!-- Use TLS to encrypt communication with SMTP server -->
 				<prop key="mail.smtp.starttls.enable">true</prop>
 			</props>
 		</property>
-		<property name="username" value="xxx@139.com" />
-		<property name="password" value="xxx" />
+		<property name="username" value="bctaxicom@163.com"/>
+		<property name="password" value="bc81560988"/>
 	</bean>
 	<!-- this is a template message that we can pre-load with default state -->
 	<bean id="templateMessage" class="org.springframework.mail.SimpleMailMessage">
-		<property name="from" value="xxx@139.com" />
-		<property name="subject" value="[BC系统邮件]" />
+		<property name="from" value="bctaxicom@163.com"/>
+		<property name="subject" value="[BC系统邮件]"/>
 	</bean>
 	<bean id="mailService" class="cn.bc.mail.MailServiceImpl">
-		<property name="mailSender" ref="mailSender" />
-		<property name="templateMessage" ref="templateMessage" />
+		<property name="operateLogService" ref="operateLogService"/>
+		<property name="idGeneratorService" ref="idGeneratorService"/>
+		<property name="optionService" ref="optionService"/>
+		<property name="mailSender" ref="mailSender"/>
+		<property name="templateMessage" ref="templateMessage"/>
+		<!-- Spring的异步任务执行器 -->
+		<property name="taskExecutor" ref="taskExecutor"/>
 		<!-- 是否使用异步方式发送邮件 -->
-		<property name="async" value="true" />
+		<property name="async" value="true"/>
 	</bean>
-
 </beans>

--- a/bc-message/src/test/resources/spring-test.xml
+++ b/bc-message/src/test/resources/spring-test.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context.xsd">
+    <bean id="taskExecutor"
+          class="org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor">
+        <property name="corePoolSize" value="10"/>
+        <property name="maxPoolSize" value="30"/>
+    </bean>
+    <!-- 平台模块配置 -->
+    <context:component-scan base-package="cn.bc.identity"/>
+    <context:component-scan base-package="cn.bc.option"/>
+    <context:component-scan base-package="cn.bc.log"/>
+
+    <import resource="classpath:cn/bc/identity/spring.xml"/>
+    <import resource="classpath:cn/bc/option/spring.xml"/>
+    <import resource="classpath:cn/bc/log/spring.xml"/>
+
+    <!-- mail 配置 -->
+    <import resource="classpath:spring-test-mail.xml"/>
+
+    <!-- 数据库配置 -->
+    <import resource="spring-test-db.xml"/>
+</beans>


### PR DESCRIPTION
经检查发现最近邮件发送失败原因为原 bc 系统邮箱密码被更改。目前临时使用用户提供的公司的 163 邮箱代替。同时由于 163 邮箱拦截功能，发送的邮件需要配置自己为抄送人才能回避拦截。
发邮件的单元测试虽然正常通过但实际邮件并没有发送成功，原因日后再查。