### PR TITLE
修正发件箱不能搜索收件人问题

### DIFF
--- a/bc-email/docs/update/20180109_收件箱表添加邮件Id字段索引.sql
+++ b/bc-email/docs/update/20180109_收件箱表添加邮件Id字段索引.sql
@@ -1,0 +1,2 @@
+﻿-- 收件箱表添加邮件 Id 字段索引
+create index bcidx_email_to_pid on bc_email_to(pid)

--- a/bc-email/src/main/java/cn/bc/email/web/struts2/EmailSendsAction.java
+++ b/bc-email/src/main/java/cn/bc/email/web/struts2/EmailSendsAction.java
@@ -129,7 +129,7 @@ public class EmailSendsAction extends ViewAction<Map<String, Object>> {
 
 	@Override
 	protected String[] getGridSearchFields() {
-		return new String[] { "e.subject"};
+		return new String[] { "e.subject", "getemailreceiver2json(e.id)"};
 	}
 
 	@Override


### PR DESCRIPTION
由于搜索匹配收件人条件耗时很多，因此需要添加 bc_email_to 表 pid 字段的索引来优化。
**所以部署时请执行 “docs/update/20180109_收件箱表添加邮件Id字段索引.sql” SQL 脚本。**